### PR TITLE
Filter accept value with a colon

### DIFF
--- a/fmf/utils.py
+++ b/fmf/utils.py
@@ -291,7 +291,7 @@ def filter(filter, data, sensitive=True, regexp=False):
         for literal in re.split(r"\s*&\s*", clause):
             # E.g. literal = 'tag: A, B'
             # Make sure the literal matches dimension:value format
-            matched = re.match(r"^(.*)\s*:\s*(.*)$", literal)
+            matched = re.match(r"^([^:]*)\s*:\s*(.*)$", literal)
             if not matched:
                 raise FilterError("Invalid filter '{0}'".format(literal))
             dimension, value = matched.groups()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -26,7 +26,10 @@ class TestFilter(object):
     """ Function filter() """
 
     def setup_method(self, method):
-        self.data = {"tag": ["Tier1", "TIPpass"], "category": "Sanity"}
+        self.data = {
+            "tag": ["Tier1", "TIPpass", "mod:S"],
+            "category": "Sanity",
+            }
 
     def test_invalid(self):
         """ Invalid filter format """
@@ -45,7 +48,9 @@ class TestFilter(object):
     def test_basic(self):
         """ Basic stuff and negation """
         assert(filter("tag: Tier1", self.data) is True)
+        assert(filter("tag: mod:S", self.data) is True)
         assert(filter("tag: -Tier2", self.data) is True)
+        assert(filter("tag: -mod:S2", self.data) is True)
         assert(filter("category: Sanity", self.data) is True)
         assert(filter("category: -Regression", self.data) is True)
         assert(filter("tag: Tier2", self.data) is False)
@@ -56,6 +61,8 @@ class TestFilter(object):
     def test_operators(self):
         """ Operators """
         assert(filter("tag: Tier1 | tag: Tier2", self.data) is True)
+        assert(filter("tag: Tier1 | tag: mod:S", self.data) is True)
+        assert(filter("tag: mod:X | tag: mod:S", self.data) is True)
         assert(filter("tag: -Tier1 | tag: -Tier2", self.data) is True)
         assert(filter("tag: Tier1 | tag: TIPpass", self.data) is True)
         assert(filter("tag: Tier1 | category: Regression", self.data) is True)
@@ -70,6 +77,7 @@ class TestFilter(object):
     def test_sugar(self):
         """ Syntactic sugar """
         assert(filter("tag: Tier1, Tier2", self.data) is True)
+        assert(filter("tag: Tier2, mod:S", self.data) is True)
         assert(filter("tag: Tier1, TIPpass", self.data) is True)
         assert(filter("tag: -Tier2", self.data) is True)
         assert(filter("tag: -Tier1, -Tier2", self.data) is True)
@@ -80,6 +88,7 @@ class TestFilter(object):
         """ Regular expressions """
         assert(filter("tag: Tier.*", self.data, regexp=True) is True)
         assert(filter("tag: Tier[123]", self.data, regexp=True) is True)
+        assert(filter("tag: mod:[XS]", self.data, regexp=True) is True)
         assert(filter("tag: NoTier.*", self.data, regexp=True) is False)
         assert(filter("tag: -Tier.*", self.data, regexp=True) is False)
 


### PR DESCRIPTION
Colon is used in e.g. module nsvc specification, with this patch it can
be used as component/tag and filter will work. No need to
strip/translate colon to other character

Resolve #140