### PR TITLE
Add support for prepending items during merging

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -89,6 +89,18 @@ Exception ``MergeError`` is raised if types are different. When
 the ``+`` suffix is applied on dictionaries ``update()`` method is
 used to merge content of given dictionary instead of replacing it.
 
+The special suffix ``+<`` can be used to prepend values instead of
+appending them. This might be handy when adjusting lists::
+
+    steps:
+      - one
+      - two
+      - three
+
+    /complete:
+        steps+<:
+          - zero
+
 In a similar way, appending a ``-`` sign will reduce or remove
 parent value from parent's attribute (which has to be defined)::
 

--- a/examples/merge/parent.fmf
+++ b/examples/merge/parent.fmf
@@ -14,6 +14,7 @@ very:
 # Child extends values instead of replacing them
 /extended:
     description+: Specific description
+    tags+<: [Tier0]
     tags+: [Tier3]
     time+: 5
     vars+:

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -147,7 +147,7 @@ class Tree:
         except ValueError:
             raise utils.FormatError("Invalid version format")
 
-    def _merge_plus(self, data, key, value):
+    def _merge_plus(self, data, key, value, prepend=False):
         """ Handle extending attributes using the '+' suffix """
         # Nothing to do if key not in parent
         if key not in data:
@@ -159,7 +159,10 @@ class Tree:
             return
         # Attempt to apply the plus operator
         try:
-            data[key] = data[key] + value
+            if prepend:
+                data[key] = value + data[key]
+            else:
+                data[key] = data[key] + value
         except TypeError as error:
             raise utils.MergeError(
                 "MergeError: Key '{0}' in {1} ({2}).".format(
@@ -197,6 +200,8 @@ class Tree:
             # Handle special attribute merging
             if key.endswith('+'):
                 self._merge_plus(data, key.rstrip('+'), value)
+            elif key.endswith('+<'):
+                self._merge_plus(data, key.rstrip('+<'), value, prepend=True)
             elif key.endswith('-'):
                 self._merge_minus(data, key.rstrip('-'), value)
             # Otherwise just update the value

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -104,7 +104,7 @@ class TestTree:
         child = self.merge.find('/parent/extended')
         assert('General' in child.data['description'])
         assert('Specific' in child.data['description'])
-        assert(child.data['tags'] == ['Tier1', 'Tier2', 'Tier3'])
+        assert(child.data['tags'] == ['Tier0', 'Tier1', 'Tier2', 'Tier3'])
         assert(child.data['time'] == 15)
         assert(child.data['vars'] == dict(x=1, y=2, z=3))
         assert(child.data['disabled'] is True)


### PR DESCRIPTION
Implement the special `+<` suffix which allows to prepend values at the
beginning of the list when merging values.

Resolves #155.