### PR TITLE
Add JSON Schema validation method

### DIFF
--- a/fmf.spec
+++ b/fmf.spec
@@ -30,6 +30,7 @@ BuildRequires: python%{python3_pkgversion}-setuptools
 BuildRequires: python%{python3_pkgversion}-pytest
 BuildRequires: python%{python3_pkgversion}-ruamel-yaml
 BuildRequires: python%{python3_pkgversion}-filelock
+BuildRequires: python%{python3_pkgversion}-jsonschema
 BuildRequires: git-core
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}
 Requires:       git-core

--- a/fmf/utils.py
+++ b/fmf/utils.py
@@ -11,6 +11,7 @@ import time
 import warnings
 from io import StringIO
 from pprint import pformat as pretty
+from typing import Any, List, NamedTuple
 
 from filelock import FileLock, Timeout
 from ruamel.yaml import YAML, scalarstring
@@ -93,6 +94,10 @@ class FetchError(GeneralError):
 
     def __str__(self):
         return self.args[0] if self.args else ''
+
+
+class JsonSchemaError(GeneralError):
+    """ Invalid JSON Schema """
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -812,3 +817,14 @@ def dict_to_yaml(data, width=None, sort=False):
 
     yaml.dump(data, output)
     return output.getvalue()
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Validation
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+class JsonSchemaValidationResult(NamedTuple):
+    """ Represents JSON Schema validation result """
+
+    result: bool
+    errors: List[Any]

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ __scripts__ = ['bin/fmf']
 # Prepare install requires and extra requires
 install_requires = [
     'ruamel.yaml',
-    'filelock'
+    'filelock',
+    'jsonschema',
     ]
 extras_require = {
     'docs': ['sphinx>=3', 'sphinx_rtd_theme'],

--- a/tests/unit/assets/schema_plan.yaml
+++ b/tests/unit/assets/schema_plan.yaml
@@ -1,0 +1,13 @@
+---
+# A dummy JSON schema used by unit tests
+
+$id: schema_plan.yaml
+
+type: object
+
+properties:
+  execute:
+    type: object
+
+required:
+  - execute

--- a/tests/unit/assets/schema_test.yaml
+++ b/tests/unit/assets/schema_test.yaml
@@ -1,0 +1,13 @@
+---
+# A dummy JSON schema used by unit tests
+
+$id: schema_test.yaml
+
+type: object
+
+properties:
+  test:
+    type: string
+
+required:
+  - test


### PR DESCRIPTION
Add method for validation JSON Schema to any node.

It validates the `data` attribute with the provided JSON
Schema passed as a loaded YAML.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>