### PR TITLE
Workaround s390x ruamel read issue

### DIFF
--- a/fmf/base.py
+++ b/fmf/base.py
@@ -435,7 +435,9 @@ class Tree:
             log.info("Checking file {0}".format(fullpath))
             try:
                 with open(fullpath, encoding='utf-8') as datafile:
-                    data = YAML(typ="safe").load(datafile)
+                    # Workadound ruamel s390x read issue - fmf/issues/164
+                    content = datafile.read()
+                    data = YAML(typ="safe").load(content)
             except (YAMLError, DuplicateKeyError) as error:
                 raise(utils.FileError(
                     f"Failed to parse '{fullpath}'.\n{error}"))


### PR DESCRIPTION
Reading file via python and then using yaml parser works
on that architecture

Fixes #164