### PR TITLE
Explicitly convert context value to string

### DIFF
--- a/docs/context.rst
+++ b/docs/context.rst
@@ -112,8 +112,9 @@ Each Dimension is a view on the Context in which metadata can be
 adjusted. For example it can be arch, distro, component, product
 or pipeline in which we run tests and so on.
 
-Each value is treated as if it was a component with version. Name
-of the dimension doesn't matter, all are treated equally.
+Values are always converted to a string representation. Each
+value is treated as if it was a component with version. Name of
+the dimension doesn't matter, all are treated equally.
 
 The characters ``:`` or ``.`` or ``-`` are used as version
 separators and are handled in the same way. The following examples

--- a/fmf/context.py
+++ b/fmf/context.py
@@ -431,7 +431,7 @@ class Context:
     @staticmethod
     def parse_value(value):
         """ Single place to convert to ContextValue """
-        return ContextValue(value)
+        return ContextValue(str(value))
 
     @staticmethod
     def split_rule_to_groups(rule):

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -399,6 +399,9 @@ class TestContextValue:
 
         assert ContextValue.compare("8", "19") == -1
 
+    def test_string_conversion(self):
+        assert Context.parse_value(1) == ContextValue("1")
+
 
 class TestParser:
     # Missing expression


### PR DESCRIPTION
Actually writing an integer value in context value
should be supported, `fmf` should take care of the conversion.

Seems this place is the best for that.

See for details https://github.com/teemtee/fmf/issues/168

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>