### PR TITLE
Allow case-insensitive matching of context dimension values

### DIFF
--- a/docs/context.rst
+++ b/docs/context.rst
@@ -123,6 +123,11 @@ Values are always converted to a string representation. Each
 value is treated as if it was a component with version. Name of
 the dimension doesn't matter, all are treated equally.
 
+Values are case-sensitive by default, which means that values like
+``centos`` and ``CentOS`` are considered different. When calling
+the ``adjust()`` method on the tree, ``case_sensitive=False`` can
+be used to make the value comparison case insensitive.
+
 The characters ``:`` or ``.`` or ``-`` are used as version
 separators and are handled in the same way. The following examples
 demonstrate how the ``name`` and ``version`` parts are parsed::

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -340,7 +340,8 @@ class Tree:
         log.debug("Data for '{0}' updated.".format(self))
         log.data(pretty(self.data))
 
-    def adjust(self, context, key='adjust', undecided='skip', decision_callback=None):
+    def adjust(self, context, key='adjust', undecided='skip',
+               case_sensitive=True, decision_callback=None):
         """
         Adjust tree data based on provided context and rules
 
@@ -354,6 +355,10 @@ class Tree:
         context dimension is not defined. By default, such rules are
         skipped. In order to raise the fmf.context.CannotDecide
         exception in such cases use undecided='raise'.
+
+        Optional 'case_sensitive' parameter can be used to specify
+        if the context dimension values should be case-sensitive when
+        matching the rules. By default, values are case-sensitive.
 
         Optional 'decision_callback' callback would be called for every adjust
         rule inspected, with three arguments: current fmf node, current
@@ -379,6 +384,8 @@ class Tree:
                     "got '{}'.".format(self.name, type(rules).__name__))
         except KeyError:
             rules = []
+
+        context.case_sensitive = case_sensitive
 
         # Check and apply each rule
         for rule in rules:
@@ -435,7 +442,8 @@ class Tree:
 
         # Adjust all child nodes as well
         for child in self.children.values():
-            child.adjust(context, key, undecided, decision_callback=decision_callback)
+            child.adjust(context, key, undecided,
+                         case_sensitive=case_sensitive, decision_callback=decision_callback)
 
     def get(self, name=None, default=None):
         """

--- a/tests/unit/test_adjust.py
+++ b/tests/unit/test_adjust.py
@@ -221,3 +221,15 @@ class TestAdjust:
         mock_callback = MagicMock(name='<mock>callback')
         mini.adjust(centos, decision_callback=mock_callback)
         mock_callback.assert_called_once_with(mini, rule, True)
+
+    def test_case_sensitive(self, mini, centos):
+        """ Make sure the adjust rules are case-sensitive by default """
+        mini.data['adjust'] = dict(when='distro = CentOS', enabled=False)
+        mini.adjust(centos)
+        assert mini.get('enabled') is True
+
+    def test_case_insensitive(self, mini, centos):
+        """ Make sure the adjust rules are case-insensitive when requested """
+        mini.data['adjust'] = dict(when='distro = CentOS', enabled=False)
+        mini.adjust(centos, case_sensitive=False)
+        assert mini.get('enabled') is False


### PR DESCRIPTION
Matching of context dimension values can now be case-insensitive by calling `fmf.Tree.adjust()` with the `case_sensitive=False` parameter. The default behavior remains case-sensitive.

I have also updated the documentation about the default behavior and added some tests.

Resolves: #186 