### PR TITLE
Drop support for `el-8` and `python-3.6`

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,14 +20,12 @@ jobs:
     trigger: pull_request
     targets:
     - fedora-all
-    - epel-8
     - epel-9
 
   - job: tests
     trigger: pull_request
     targets:
     - fedora-all
-    - epel-8
     - epel-9
 
   - job: copr_build
@@ -35,7 +33,6 @@ jobs:
     branch: main
     targets:
     - fedora-all
-    - epel-8
     - epel-9
     list_on_homepage: True
     preserve_project: True

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,10 @@ default_setup = dict(
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12'
         'Topic :: Utilities',
         ],
     keywords=['metadata', 'testing'],


### PR DESCRIPTION
In alignment with `tmt` we're going to drop support for the old Python 3.6 in order to be able to use some of the more recent features and prevent unnecessary workarounds.