### PR TITLE
Add a `Toolbelt Catalog` entry for `fmf`

### DIFF
--- a/docs/toolbelt-catalog.yaml
+++ b/docs/toolbelt-catalog.yaml
@@ -1,0 +1,42 @@
+# Catalog entry for Backstage [backstage.io]
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+    name: fmf
+    title: fmf
+    description:
+        The `fmf` Python module and command line tool implement a
+        flexible format for defining metadata in plain text files
+        which can be stored close to the source code. Thanks to
+        hierarchical structure with support for inheritance and
+        elasticity it provides an efficient way to organize data
+        into well-sized text documents.
+    annotations:
+        github.com/project-slug: teemtee/fmf
+        feedback/type: JIRA
+        feedback/host: https://issues.redhat.com
+        jira/project-key: TT
+        feedback/email-to: tmt@redhat.com
+    links:
+      - title: docs
+        url: https://fmf.readthedocs.io
+        icon: docs
+      - title: code
+        url: https://github.com/teemtee/fmf/
+        icon: github
+      - title: pypi
+        url: https://pypi.org/project/fmf
+      - title: copr
+        url: https://copr.fedorainfracloud.org/coprs/g/teemtee/fmf/
+      - title: "#tmt"
+        url: https://app.slack.com/client/E030G10V24F/C04LRPNDZ4Y
+        icon: chat
+    tags:
+        - test-metadata
+        - python
+    namespace: quality-community
+spec:
+    type: library
+    owner: group:redhat/tmt
+    lifecycle: production


### PR DESCRIPTION
To be used to build the `Toolbelt Catalog`.
Fix https://issues.redhat.com/browse/QC-66