### PR TITLE
Limit number of tests run for integration with tmt

### DIFF
--- a/plans/integration.fmf
+++ b/plans/integration.fmf
@@ -4,7 +4,7 @@ discover:
     how: fmf
     url: https://github.com/teemtee/tmt
     ref: fedora
-    filter: 'tier: 1, 2'
+    filter: 'tier: 1 & tag:-provision-only'
 prepare:
   - how: install
     package:


### PR DESCRIPTION
Just Tier:1 and only with 'local' provision.
We need to check fmf format works, not tmt features...