### PR TITLE
Accept additional rules in the `adjust()` call

### DIFF
--- a/fmf/base.py
+++ b/fmf/base.py
@@ -368,9 +368,9 @@ class Tree:
         adjust rule, and whether it was applied or not.
 
         Optional 'additional_rules' parameter can be used to specify rules
-        which should be applied in addition to those defined in the node itself.
-        These additional rules are processed even when the applied
-        rule defined in the data has ``continue: false`` set.
+        that should be applied after those from the node itself.
+        These additional rules are processed even when an applied
+        rule defined in the node has ``continue: false`` set.
         """
 
         # Check context sanity

--- a/tests/unit/test_adjust.py
+++ b/tests/unit/test_adjust.py
@@ -127,6 +127,11 @@ class TestAdjust:
         mini.adjust(centos)
         assert mini.get('enabled') is False
 
+    def test_adjusted_additional(self, mini, centos):
+        """ Additional rule is evaluated even if 'main' rule matched """
+        mini.adjust(centos, additional_rules={'enabled': True})
+        assert mini.get('enabled') is True
+
     def test_keep_original_adjust_rules(self, mini, centos):
         original_adjust = copy.deepcopy(mini.get('adjust'))
         mini.adjust(centos)
@@ -210,6 +215,8 @@ class TestAdjust:
         # From the mini tree
         rule = mini.data['adjust']
 
+        add_rule = {"when": "distro == centos", "foo": "bar"}
+
         mock_callback = MagicMock(name='<mock>callback')
         mini.adjust(fmf.Context(), decision_callback=mock_callback)
         mock_callback.assert_called_once_with(mini, rule, None)
@@ -221,6 +228,12 @@ class TestAdjust:
         mock_callback = MagicMock(name='<mock>callback')
         mini.adjust(centos, decision_callback=mock_callback)
         mock_callback.assert_called_once_with(mini, rule, True)
+
+        mock_callback = MagicMock(name='<mock>callback')
+        mini.adjust(centos, decision_callback=mock_callback, additional_rules=[add_rule])
+        mock_callback.assert_any_call(mini, rule, True)
+        mock_callback.assert_any_call(mini, add_rule, True)
+        assert mock_callback.call_count == 2
 
     def test_case_sensitive(self, mini, centos):
         """ Make sure the adjust rules are case-sensitive by default """

--- a/tests/unit/test_adjust.py
+++ b/tests/unit/test_adjust.py
@@ -132,6 +132,19 @@ class TestAdjust:
         mini.adjust(centos, additional_rules={'enabled': True})
         assert mini.get('enabled') is True
 
+    def test_adjusted_additional_after_continue(self, full, centos):
+        """ Additional rule is evaluated even if 'node' rule has continue:false """
+        full.adjust(centos,
+                    additional_rules=[{'tag': 'foo'},
+                                      {'require': 'bar',
+                                       'continue': False,
+                                       'when': 'distro == centos'},
+                                      {'recommend': 'baz'}])
+        assert full.get('enabled') is False
+        assert full.get('tag') == 'foo'
+        assert full.get('require') == 'bar'
+        assert full.get('recommend', []) == []
+
     def test_keep_original_adjust_rules(self, mini, centos):
         original_adjust = copy.deepcopy(mini.get('adjust'))
         mini.adjust(centos)


### PR DESCRIPTION
Use case: Explicit set of the rules to be applied, regardless what is in  the Tree.

Could be simplified if/once #229 is merged.

