### PR TITLE
Use the `referencing` library where available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-tmt.1
+fmf.1
 
 # Testing
 .mypy_cache

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,77 @@ dist
 docs/_build
 docs/spec
 docs/stories
-__pycache__
+
+# Python
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+tmt.1
+
+# Testing
+.mypy_cache
+.pytest_cache
+*.tgz
+# Created by pytest-html reporting plugin
+/assets/style.css
+/report.html
+
+# Virtual environment
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Jetbrains
+.idea/
+
+# Vim
+
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+
+# Auto-generated tag files
+tags
+
+# Persistent undo
+[._]*.un~
+
+# Visual Studio Code
+.vscode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,6 @@ repos:
           - --recursive
           - --in-place
           - --aggressive
-          - --aggressive
           - --hang-closing
           - --max-line-length=99
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
           - --recursive
           - --in-place
           - --aggressive
+          - --aggressive
           - --hang-closing
           - --max-line-length=99
 

--- a/fmf/_compat/jsonschema.py
+++ b/fmf/_compat/jsonschema.py
@@ -1,0 +1,51 @@
+"""Compatibility layer for jsonschema validation."""
+
+from typing import Any, Optional
+
+import jsonschema
+from jsonschema.validators import Draft4Validator
+
+
+def get_validator(
+        schema: Any,
+        schema_store: Optional[dict[str, Any]] = None
+        ) -> Draft4Validator:
+    """Create a validator instance based on available jsonschema version."""
+    # Validate schema is a dict
+    if not isinstance(schema, dict):  # TODO remove once mypy/pyright is added
+        from fmf.utils import JsonSchemaError
+        raise JsonSchemaError(f'Invalid schema type: {type(schema)}. Schema must be a dictionary.')
+
+    schema_store = schema_store or {}
+
+    try:
+        from jsonschema import validators
+        from referencing import Registry, Resource
+        from referencing.jsonschema import DRAFT4
+
+        # Modern approach with referencing
+        resources = []
+        for uri, contents in schema_store.items():
+            # Try to create resource from contents (will use $schema if present)
+            try:
+                resource = Resource.from_contents(contents)
+            except Exception:
+                # If that fails, explicitly create as Draft4
+                resource = DRAFT4.create_resource(contents)
+            resources.append((uri, resource))
+
+        registry = Registry().with_resources(resources)
+
+        # Create validator using Draft4 meta-schema
+        validator_cls = validators.validator_for(schema, default=Draft4Validator)
+        return validator_cls(schema=schema, registry=registry)
+
+    except ImportError:
+        # Legacy approach with RefResolver
+        try:
+            resolver = jsonschema.RefResolver.from_schema(
+                schema, store=schema_store)
+        except AttributeError as error:
+            from fmf.utils import JsonSchemaError
+            raise JsonSchemaError(f'Provided schema cannot be loaded: {error}')
+        return Draft4Validator(schema, resolver=resolver)

--- a/fmf/utils.py
+++ b/fmf/utils.py
@@ -913,7 +913,7 @@ def dict_to_yaml(data, width=None, sort=False):
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 class JsonSchemaValidationResult(NamedTuple):
-    """Represents JSON Schema validation result."""
+    """ Represents JSON Schema validation result """
     result: bool
     errors: list[Any]
 
@@ -944,7 +944,6 @@ def validate_data(
             jsonschema.exceptions.RefResolutionError,
             jsonschema.exceptions.UnknownType
             ) as error:
-        from fmf.utils import JsonSchemaError
         raise JsonSchemaError(f'Errors found in provided schema: {error}')
 
 


### PR DESCRIPTION
Use the `referencing` library where available instead of deprecated `jsonschema.RefResolver`.

Addressing https://github.com/teemtee/fmf/issues/194 .

Getting rid of deprecation warnings. 