### PR TITLE
Allow dashes in context dimension names

### DIFF
--- a/docs/context.rst
+++ b/docs/context.rst
@@ -45,7 +45,7 @@ supported operators consult the following grammar outline::
     expression ::= dimension binary_operator values
     expression ::= dimension unary_operator
     expression ::= 'true' | 'false'
-    dimension ::= [[:alnum:]]+
+    dimension ::= [[:alnum:-]]+
     binary_operator ::= '==' | '!=' | '<' | '<=' | '>' | '>=' |
         '~=' | '~!=' | '~<' | '~<=' | '~>' | '~>=' | '~' | '!~'
     unary_operator ::= 'is defined' | 'is not defined'

--- a/fmf/context.py
+++ b/fmf/context.py
@@ -397,7 +397,7 @@ class Context:
     # Triple expression: dimension operator values
     # [^=].* is necessary as .+ matches '= something'
     re_expression_triple = re.compile(
-        r"(\w+)"
+        r"([\w-]+)"
         + r"\s*("
         + r"|".join(
             [key for key in operator_map if key not in ["is defined", "is not defined"]])
@@ -405,7 +405,7 @@ class Context:
         + r"([^=].*)")
     # Double expression: dimension operator
     re_expression_double = re.compile(
-        r"(\w+)" + r"\s*(" + r"|".join(["is defined", "is not defined"]) + r")"
+        r"([\w-]+)" + r"\s*(" + r"|".join(["is defined", "is not defined"]) + r")"
         )
 
     # Simple boolean value

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -535,6 +535,10 @@ class TestParser:
         assert Context.split_expression("dim < value , second") == (
             "dim", "<", ["value", "second"])
         assert Context.split_expression("true") == (None, True, None)
+        assert Context.split_expression("provision-method == local") == (
+            "provision-method", "==", ["local"])
+        assert Context.split_expression("provision-method is defined") == (
+            "provision-method", "is defined", None)
 
     def test_parse_rule(self):
         """ Rule parsing """


### PR DESCRIPTION
It's quite common to name multi-word keys with dashes instead of underscores. Let's allow dashes in the context dimension names as well.