### PR TITLE
Use `sphinx.ext.autosectionlabel`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ sys.path.insert(0, os.path.abspath('../'))
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosectionlabel',
     'sphinx_rtd_theme',
     ]
 
@@ -204,6 +205,8 @@ html_static_path = ['_static']
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'fmfdoc'
+
+autosectionlabel_maxdepth = 2
 
 # -- Options for manual page output ---------------------------------------
 


### PR DESCRIPTION
I was trying to link to the [hierarchy section](https://fmf.readthedocs.io/en/latest/features.html#hierarchy) using intersphinx links, but I couldn't find the target for it similar to how `select` is available. This is mostly because the sections are not auto-labeled. This should make linking easier for external documentations.

Not sure if `autosectionlabel_prefix_document` would also be necessary.