### PR TITLE
Keep order of the operation when merging values

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -218,6 +218,21 @@ strings::
 
 __ https://docs.python.org/3/library/re.html#regular-expression-syntax
 
+.. note::
+
+    When multiple merge operations are performed on a single key,
+    they are applied in the order in which they are defined. For
+    example, the following two definitions will have a different
+    result::
+
+        /remove-first:
+            tag-: [two, three]
+            tag+: [three, four]
+
+        /append-first:
+            tag+: [three, four]
+            tag-: [two, three]
+
 
 Elasticity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/merge/parent.fmf
+++ b/examples/merge/parent.fmf
@@ -51,3 +51,15 @@ very:
     - '.ier1'
     vars-~:
     - 'y'
+
+# Inheritance should be applied in the given order
+/order:
+    tag: [one, two]
+
+    /add-first:
+        tag+: [three, four]
+        tag-: [two, three]
+
+    /remove-first:
+        tag-: [two, three]
+        tag+: [three, four]

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -294,7 +294,7 @@ class Tree:
 
     def _merge_special(self, data, source):
         """ Merge source dict into data, handle special suffixes """
-        for key, value in sorted(source.items()):
+        for key, value in source.items():
             # Handle special attribute merging
             if key.endswith('+'):
                 self._merge_plus(data, key.rstrip('+'), value)
@@ -400,7 +400,7 @@ class Tree:
             pass
 
         # Process the metadata
-        for key, value in sorted(data.items()):
+        for key, value in data.items():
             # Ensure there are no 'None' keys
             if key is None:
                 raise utils.FormatError("Invalid key 'None'.")

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -671,7 +671,7 @@ class Tree:
         """ Climb through the tree (iterate leaf/all nodes) """
         if whole or self.select:
             yield self
-        for name, child in self.children.items():
+        for name, child in sorted(self.children.items()):
             for node in child.climb(whole):
                 yield node
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -224,6 +224,13 @@ class TestTree:
         child = self.merge.find('/parent/buried')
         assert child.data['very']['deep']['dict'] == dict(x=2, y=1, z=0)
 
+    def test_merge_order(self):
+        """ Inheritance should be applied in the given order """
+        child = self.merge.find('/parent/order/add-first')
+        assert child.data['tag'] == ['one', 'four']
+        child = self.merge.find('/parent/order/remove-first')
+        assert child.data['tag'] == ['one', 'three', 'four']
+
     def test_get(self):
         """ Get attributes """
         assert isinstance(self.wget.get(), dict)


### PR DESCRIPTION
When inheriting, do not sort the keys but apply the merging operation in the original order provided by the user.

Fix #232.