### PR TITLE
Handle nested `dict` extending non-existent keys

### DIFF
--- a/examples/deep/main.fmf
+++ b/examples/deep/main.fmf
@@ -19,3 +19,22 @@ hardware:
         size: 8
     network:
         model: e1000
+
+# A deep dictionary extending non-existent values
+/single:
+    undefined+:
+        deeper+:
+            key: value
+
+# And a child with a similar deep dictionary
+/parent:
+    one: 1
+    two: 2
+
+    /child:
+        one+: 1
+        two+: 2
+        three+: 3
+        undefined+:
+            deeper+:
+                key: value

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -175,7 +175,13 @@ class Tree:
 
         # Set the value if key is not present
         if key not in data:
-            data[key] = value
+            # Special handling for dictionaries as their keys might
+            # contain suffixes which should be removed
+            if isinstance(value, dict):
+                data[key] = {}
+                self._merge_special(data[key], value)
+            else:
+                data[key] = value
             return
 
         # Parent is a list of dict and child is a dict

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -147,6 +147,17 @@ class TestTree:
         assert deep.get(['hardware', 'bad', 'size'], 12) == 12
         assert deep.get('nonexistent', default=3) == 3
 
+    def test_deep_dictionary_undefined_keys(self):
+        """ Extending undefined keys using '+' should work """
+        deep = Tree(EXAMPLES + "deep")
+        single = deep.find("/single")
+        assert single.get(["undefined", "deeper", "key"]) == "value"
+        child = deep.find("/parent/child")
+        assert child.get("one") == 2
+        assert child.get("two") == 4
+        assert child.get("three") == 3
+        assert child.get(["undefined", "deeper", "key"]) == "value"
+
     def test_merge_plus(self):
         """ Extending attributes using the '+' suffix """
         child = self.merge.find('/parent/extended')

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -137,7 +137,7 @@ class TestTree:
     def test_deep_hierarchy(self):
         """ Deep hierarchy on one line """
         deep = Tree(EXAMPLES + "deep")
-        assert len(deep.children) == 1
+        assert len(deep.children) == 3
 
     def test_deep_dictionary(self):
         """ Get value from a deep dictionary """


### PR DESCRIPTION
When merging nested dictionaries we should use `_merge_special()` in order to make sure that possible key suffixes are removed.

Fix #190.