### PR TITLE
Use `hatch version` instead of packit default

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -48,6 +48,7 @@ jobs:
     targets: *targets
     <<: *copr
     project: latest
+    release_suffix: "{PACKIT_PROJECT_BRANCH}"
 
   # Build release (copr stable)
   - job: copr_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,6 +10,8 @@ actions:
   create-archive:
     - "hatch build -t sdist"
     - "sh -c 'echo dist/fmf-*.tar.gz'"
+  get-current-version:
+    - hatch version
 
 # Common definitions
 _:

--- a/fmf.spec
+++ b/fmf.spec
@@ -15,6 +15,7 @@ BuildRequires: python3dist(docutils)
 BuildRequires: git-core
 Requires:      git-core
 
+Obsoletes:     python3-fmf < %{version}-%{release}
 %py_provides   python3-fmf
 
 %description


### PR DESCRIPTION
By default packit creates rpms with version which can be older than packages already released in Fedora repositories. We need to use `hatch version` to at least bump the micro version.