### PR TITLE
Sync the `.packit.yaml` config to downstream repo

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,5 +1,7 @@
 specfile_path: fmf.spec
-files_to_sync: [fmf.spec]
+files_to_sync:
+  - fmf.spec
+  - .packit.yaml
 
 upstream_package_name: fmf
 downstream_package_name: fmf


### PR DESCRIPTION
The config file needs to be present in the `rawhide` branch of dist-git to actually enable the `propose_downstream` feature. Let's keep the file in sync.