### PR TITLE
Set up default owners and the pull request checklist

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence
+*   @psss @lukaszachy @happz @thrix @janhavlin @martinhoyer

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+Pull Request Checklist
+
+* [ ] implement the feature
+* [ ] write the documentation
+* [ ] extend the test coverage
+* [ ] mention the version
+* [ ] include a release note

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Pull Request Checklist
+## Checklist
 
 * [ ] implement the feature
 * [ ] write the documentation


### PR DESCRIPTION
Let's enable the `CODEOWNERS` file so that we do not have to ask for review manually for each pull request. Also add the pull request checklist so that we don't forget about the important steps (like including the release note which was missing in all recent pulls).