### PR TITLE
Make sorting in `climb()` and `prune()` configurable

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -324,26 +324,6 @@ instead of deleting it completely. To do so, one can set the directive::
 By default all leaves have it set to ``true`` (such node is selected)
 and branches have set it to ``false`` (such node is not selected).
 
-.. _sort:
-
-Sort
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-By default, when exploring test metadata in the tree, child nodes
-are sorted alphabetically by node name. This applies to command
-line usage such as ``fmf ls`` or ``fmf show`` as well as for the
-:py:meth:`fmf.Tree.climb()` and :py:meth:`fmf.Tree.prune()`
-methods.
-
-If the tree content is not created from files on disk but created
-manually using the :py:meth:`fmf.Tree.child()` method, the child
-order can be preserved by providing the ``sort=False`` parameter
-to the :py:meth:`fmf.Tree.climb()` and :py:meth:`fmf.Tree.prune()`
-methods.
-
-.. versionadded:: 1.6
-
-
 .. _virtual:
 
 Virtual

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -324,6 +324,26 @@ instead of deleting it completely. To do so, one can set the directive::
 By default all leaves have it set to ``true`` (such node is selected)
 and branches have set it to ``false`` (such node is not selected).
 
+.. _sort:
+
+Sort
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, when exploring test metadata in the tree, child nodes
+are sorted alphabetically by node name. This applies to command
+line usage such as ``fmf ls`` or ``fmf show`` as well as for the
+:py:meth:`fmf.Tree.climb()` and :py:meth:`fmf.Tree.prune()`
+methods.
+
+If the tree content is not created from files on disk but created
+manually using the :py:meth:`fmf.Tree.child()` method, the child
+order can be preserved by providing the ``sort=False`` parameter
+to the :py:meth:`fmf.Tree.climb()` and :py:meth:`fmf.Tree.prune()`
+methods.
+
+.. versionadded:: 1.6
+
+
 .. _virtual:
 
 Virtual

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -3,6 +3,29 @@
     Modules
 ===============
 
+.. _sort:
+
+Sort
+----
+
+By default, when exploring test metadata in the tree, child nodes
+are sorted alphabetically by node name. This applies to command
+line usage such as ``fmf ls`` or ``fmf show`` as well as for the
+:py:meth:`fmf.Tree.climb()` and :py:meth:`fmf.Tree.prune()`
+methods.
+
+If the tree content is not created from files on disk but created
+manually using the :py:meth:`fmf.Tree.child()` method, the child
+order can be preserved by providing the ``sort=False`` parameter
+to the :py:meth:`fmf.Tree.climb()` and :py:meth:`fmf.Tree.prune()`
+methods.
+
+.. versionadded:: 1.6
+
+
+fmf
+---
+
 .. automodule:: fmf
     :members:
     :undoc-members:

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -12,6 +12,12 @@ In order to search :ref:`context` dimension values using regular
 expressions, it is now possible to use operator ``~`` for matching
 patterns and operator ``!~`` for non matching patterns.
 
+When exploring trees using the :py:meth:`fmf.Tree.climb()` and
+:py:meth:`fmf.Tree.prune()` methods, optional parameter ``sort``
+can be used to preserve the original order in which child nodes
+where inserted into the tree. See the :ref:`sort` section for more
+details.
+
 
 fmf-1.5.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -80,6 +80,27 @@ class TestTree:
         child = Tree(EXAMPLES + "child")
         assert child.find("/nobody") is None
 
+    def test_insert_child(self):
+        """ Manual child creation """
+
+        # Prepare a simple tree by manually inserting child nodes
+        tree = Tree(data={"key": "value"})
+        tree.child(name="child2", data={"key": "value"})
+        tree.child(name="child3", data={"key": "value"})
+        tree.child(name="child1", data={"key": "value"})
+
+        # By default, node names should be sorted when climbing & prunning
+        expected = ['/child1', '/child2', '/child3']
+        assert [node.name for node in tree.climb()] == expected
+        assert [node.name for node in tree.prune()] == expected
+        assert [node.name for node in tree.climb(sort=True)] == expected
+        assert [node.name for node in tree.prune(sort=True)] == expected
+
+        # Original order should be kept if requested
+        expected = ['/child2', '/child3', '/child1']
+        assert [node.name for node in tree.climb(sort=False)] == expected
+        assert [node.name for node in tree.prune(sort=False)] == expected
+
     def test_prune_sources(self):
         """ Pruning by sources """
         original_directory = os.getcwd()


### PR DESCRIPTION
Allow users to disable sorting by node names and preserve the order in which child nodes where inserted into the tree.

## Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage
* [x] mention the version
* [x] include a release note
