### PR TITLE
Use packit for building rpms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ man: tmp
 # RPM packaging
 tarball: man
 	hatch build -t sdist
-rpm: tarball
-	rpmbuild --define '_topdir $(TMP)' -bb fmf.spec
-srpm: tarball
-	rpmbuild --define '_topdir $(TMP)' -bs fmf.spec
+rpm:
+	packit build in-mock --resuldir mock-rpm
+srpm:
+	packit srpm
 packages: rpm srpm
 
 


### PR DESCRIPTION
Packit recently added the resuldir for building with mock which was a partial blocker for switching the makefile to using it. The checking if `mock` cli actually works proved a bit more complicated [^1], but would it be a blocker?

To discusss:
- For srpm build, do we let packit decide on the srpm name, which would make it like: `fmf-1.6.1.dev1+g1c5d676-1.20250108095718984812.makefile.1.g1c5d676.fc41.src.rpm`
- For `packit build in-mock` where should the `resultdir` point to?
- Do we make the mock root configurable with `Release`/`arch` variables?
- `.gitignore` entries

[^1]: https://github.com/packit/packit/issues/2472