### PR TITLE
Add an explicit sphinx configuration for docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,14 @@
 # Config for building https://fmf.readthedocs.io/
 version: 2
+
+sphinx:
+    configuration: docs/conf.py
+
 build:
     os: ubuntu-22.04
     tools:
         python: "3"
+
 python:
     install:
       - method: pip


### PR DESCRIPTION
The readthedocs config file now has to explicitly mention the config file location. See the blog post for more details:

https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/