### PR TITLE
Keep merge suffix for nested dictionaries

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -98,6 +98,9 @@ or when merging a dictionary with a list.
 Exception ``MergeError`` is raised if types are not compatible. When
 the ``+`` suffix is applied on dictionaries ``update()`` method is
 used to merge content of given dictionary instead of replacing it.
+When such parent dictionary doesn't exist, but the suffix ``+`` is used
+at the top level, the dictionary is created and named without the suffix.
+However, for dictionaries at deeper levels, the suffix remains in their name.
 
 Example: Merging dictionary with a list::
 
@@ -158,6 +161,25 @@ results in::
           - how: fmf
             url: https://github.com/project2
             filter: "tier:2"
+
+Example: Merging with not yet defined dictionaries::
+
+    environment+:
+        CLEAR: "1"
+    adjust+:
+        when: distro == fedora
+        environment+:
+            FEDORA: "1"
+
+results in (no ``+`` suffix in ``adjust`` and top ``environment`` keys)::
+
+    adjust:
+        when: distro == fedora
+        environment+:
+            FEDORA: "1"
+    environment:
+        CLEAR: "1"
+
 
 The special suffix ``+<`` can be used to prepend values instead of
 appending them. This might be handy when adjusting lists::

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,14 @@
     Releases
 ======================
 
+fmf-1.6.1
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to allow adjust rules to merge dictionaries, nested
+dictionaries need to keep the suffix in their name. This behavior
+reverts to fmf-1.4.0 and is now documented in :ref:`merging<merging>`
+section.
+
 
 fmf-1.6.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/deep/main.fmf
+++ b/examples/deep/main.fmf
@@ -21,6 +21,7 @@ hardware:
         model: e1000
 
 # A deep dictionary extending non-existent values
+# should keep '+' (important for adjust)
 /single:
     undefined+:
         deeper+:

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -190,13 +190,7 @@ class Tree:
 
         # Set the value if key is not present
         if key not in data:
-            # Special handling for dictionaries as their keys might
-            # contain suffixes which should be removed
-            if isinstance(value, dict):
-                data[key] = {}
-                self._merge_special(data[key], value)
-            else:
-                data[key] = value
+            data[key] = value
             return
 
         # Parent is a list of dict and child is a dict


### PR DESCRIPTION
This is necessary to make possible merging dictionaries in adjust rules. Otherwise they would be always set (instead of update).

Fix: #276
Reopen: #190

## Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage
* [x] include a release note
