### PR TITLE
Strip merge suffix in root node as well

### DIFF
--- a/examples/merge/main.fmf
+++ b/examples/merge/main.fmf
@@ -1,0 +1,3 @@
+# Merge suffix can be used and will be stripped
+environment+:
+    SOME: value

--- a/examples/merge/stray.fmf
+++ b/examples/merge/stray.fmf
@@ -1,0 +1,6 @@
+/:
+  inherit: false
+
+# Merge suffix will be stripped
+environment+:
+    NOTHING: here

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -372,17 +372,15 @@ class Tree:
 
     def merge(self, parent=None):
         """ Merge parent data """
-        # Check parent, append source files
+        # Check parent
         if parent is None:
             parent = self.parent
-        if parent is None:
-            return
-        # Do not inherit when disabled
-        if self._directives.get("inherit") is False:
-            return
-        self.sources = parent.sources + self.sources
-        # Merge child data with parent data
-        data = copy.deepcopy(parent.data)
+        if self._directives.get("inherit") is False or parent is None:
+            # Nothing to inherit
+            data = {}
+        else:
+            self.sources = parent.sources + self.sources
+            data = copy.deepcopy(parent.data)
         self._merge_special(data, self.data)
         self.data = data
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -174,6 +174,14 @@ class TestTree:
         assert child.data['environment']['FOO'] == "bar"
         assert child.data['environment']['BAR'] == "baz"
 
+    def test_node_without_parent_strips_merge_suffix(self):
+        """ Merge suffix is stripped in the top node as well """
+        tree = Tree(EXAMPLES + 'merge')
+        stray_child = tree.find('/stray')
+        assert 'environment' in stray_child.data
+        child = tree.find('/parent/reduced')
+        assert 'environment' in child.data
+
     def test_deep_hierarchy(self):
         """ Deep hierarchy on one line """
         deep = Tree(EXAMPLES + "deep")


### PR DESCRIPTION
 Otherwise `key+` defined in root node or node with broken
 inheritance will be called `key+` instead of `key`.
 All other nodes already strip the merge suffix
    
  Fix: #277

## Checklist

* [X] implement the feature
* [X] extend the test coverage
