### PR TITLE
Add callback to limit which nodes are adjusted

### DIFF
--- a/fmf/base.py
+++ b/fmf/base.py
@@ -50,6 +50,22 @@ class AdjustCallback(Protocol):
         pass
 
 
+class ApplyRulesCallback(Protocol):
+    """
+    A callback to decide if rules should be processed in Tree.adjust()
+
+    Function to be called for every node before ``additional_rules``
+    are processed. It is called with fmf tree as the parameter.
+    It should return ``True`` when additional_rules should be processed
+    or ``False`` when they should be ignored.
+    """
+
+    def __call__(
+            self,
+            node: 'Tree') -> bool:
+        return True
+
+
 class Tree:
     """ Metadata Tree """
 
@@ -436,7 +452,8 @@ class Tree:
 
     def adjust(self, context, key='adjust', undecided='skip',
                case_sensitive=True, decision_callback=None,
-               additional_rules=None, additional_rules_callback=None):
+               additional_rules=None,
+               additional_rules_callback: Optional[ApplyRulesCallback] = None):
         """
         Adjust tree data based on provided context and rules
 

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -482,9 +482,10 @@ class Tree:
         rule defined in the node has ``continue: false`` set.
 
         Optional 'additional_rules_callback' callback could be set to
-        limit nodes for which 'additional_rules' are processed.
-        This callback is called current fmf node as an argument and should
-        return 'True' to process 'additional_rules' or 'False' to skip them.
+        limit nodes for which 'additional_rules' are processed. This
+        callback is called with the current fmf node as an argument and
+        should return 'True' to process 'additional_rules' or 'False' to
+        skip them.
         """
 
         # Check context sanity


### PR DESCRIPTION
Especially from 'tmt' we want to adjust just tests and keep other types of nodes intact (plan, story).

## Checklist

* [x] implement the feature
* [ ] write the documentation
* [x] extend the test coverage
* [ ] mention the version
* [ ] include a release note
