### PR TITLE
Add ContextValue version_cmp method tests for CentOS Stream and RHEL

### DIFF
--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -480,6 +480,40 @@ class TestContextValue:
         assert frawhide.version_cmp(f33) > 0
         assert f33.version_cmp(frawhide) < 0
 
+    def test_version_cmp_centos_stream(self):
+        """
+        CentOS Stream comparison
+        """
+
+        cs9 = ContextValue("centos-stream-9")
+        csrawhide = ContextValue("centos-stream-rawhide")
+
+        assert cs9.version_cmp(ContextValue("centos-stream-9")) == 0
+        assert cs9.version_cmp(ContextValue("centos-stream-8")) > 0
+        assert cs9.version_cmp(ContextValue("centos-stream-10")) < 0
+
+        assert csrawhide.version_cmp(ContextValue("centos-stream-rawhide")) == 0
+        assert csrawhide.version_cmp(cs9) > 0
+        assert cs9.version_cmp(csrawhide) < 0
+
+    def test_version_cmp_rhel(self):
+        """
+        RHEL comparison
+        """
+
+        rhel9_1 = ContextValue("rhel-9.1")
+        rhel9_rawhide = ContextValue("rhel-9.rawhide")
+
+        assert rhel9_1.version_cmp(ContextValue("rhel-9.1")) == 0
+        assert rhel9_1.version_cmp(ContextValue("rhel-9")) == 0
+        assert rhel9_1.version_cmp(ContextValue("rhel-9.0")) > 0
+        assert rhel9_1.version_cmp(ContextValue("rhel-9.2")) < 0
+        assert rhel9_1.version_cmp(ContextValue("rhel-10")) < 0
+
+        assert rhel9_rawhide.version_cmp(ContextValue("rhel-9.rawhide")) == 0
+        assert rhel9_rawhide.version_cmp(rhel9_1) > 0
+        assert rhel9_1.version_cmp(rhel9_rawhide) < 0
+
     def test_prints(self):
         f33 = ContextValue("fedora-33")
         str(f33)


### PR DESCRIPTION
Add the test_version_cmp_centos_stream and test_version_cmp_rhel.

The main purpose to add these tests is to make sure the `distro: centos-stream-rawhide` and `distro: rhel-X.rawhide` such as `distro: rhel-10.rawhide`, `distro: rhel-9.rawhide` work.
Because I heard that the `distro: rhel-10.rawhide` work

For the documentation, there is the following document about the `fedora-rawahide`. Let me know if you want to update the document with centos-stream and rhel.

https://fmf.readthedocs.io/en/stable/context.html#context
https://github.com/teemtee/fmf/blob/39af408279b305bd8744e1a74c4ad09958394587/docs/context.rst#major-version

> fedora-33 < fedora-rawhide ---> True (rawhide is newer than any number)

## Checklist

* [X] implement the feature
* [ ] write the documentation
* [X] extend the test coverage
* [ ] mention the version
* [ ] include a release note
