### PR TITLE
Update `/plans/integration` tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -37,6 +37,8 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets: *targets
+    additional_repos:
+      - "copr://@teemtee/latest"
 
   # Test pull requests
   - job: tests

--- a/plans/integration.fmf
+++ b/plans/integration.fmf
@@ -2,7 +2,6 @@ summary:
     Run integration tests with tmt
 discover:
     how: fmf
-    url: https://github.com/teemtee/tmt
     filter: 'tier: 1 & tag:-provision-only'
 prepare:
   - how: install
@@ -10,3 +9,28 @@ prepare:
       - jq
       - yq
       - python3-pip
+enabled: false
+
+adjust:
+  - when: initiator == packit
+    because: >
+      We want to test against the tmt main branch
+    prepare+:
+      - how: install
+        copr: "@teemtee/latest"
+    discover+:
+      url: https://github.com/teemtee/tmt
+      ref: main
+    enabled: true
+  - when: initiator == fedora-ci
+    because: >
+      We want to test against the source in Fedora
+    discover+:
+      dist-git-source: true
+      # Technically we do not want to do dist-git-merge, but it is safe for us right now
+      # because there are no clashing test definitions
+      # https://github.com/teemtee/tmt/issues/4840
+      dist-git-merge: true
+      url: https://src.fedoraproject.org/rpms/tmt.git
+      ref: $@{dist-git-branch}
+    enabled: true

--- a/plans/integration.fmf
+++ b/plans/integration.fmf
@@ -3,23 +3,10 @@ summary:
 discover:
     how: fmf
     url: https://github.com/teemtee/tmt
-    ref: fedora
     filter: 'tier: 1 & tag:-provision-only'
 prepare:
   - how: install
     package:
       - jq
+      - yq
       - python3-pip
-      - tmt-all
-  - how: shell
-    script:
-      # Try to install into .local first, if that fails, try without --user.
-      # In the sane world, tmt would be running in a virtualenv, and we'd
-      # install yq there. Otherwise, we'd change system packages, but we'd
-      # have to run as root to do that, and who's running tmt test suite
-      # as root?
-      #
-      # We need to freeze yq to 3.1.1 so that it's installable on el8 as
-      # newer yq requires tomlkit>=0.11.7 which is python 3.7+ only.
-      - pip3 install --user yq==3.1.1 || pip3 install yq==3.1.1
-      - yq --help


### PR DESCRIPTION
The state of `/plans/integration` has been out-of-sync for a while, namely that we do not use python `yq` anymore. Ideally we would use the `plans/friends` in tmt to have tmt handle the necessary dependencies. That is waiting on https://github.com/teemtee/tmt/pull/4841.

In the meantime we are doing some cleanup of the plan here partially reflecting the design described in https://github.com/teemtee/tmt/pull/4841.
- Drop the usage of `fedora` branch which is not being updated automatically. There are some ideas of how we could bring it back to track which should be discussed in https://github.com/teemtee/tmt/pull/4841 and its followups
- Track the `@teemtee/latest` copr (tmt `main` branch)
- Add a design that is reusable in downstream packaging as well, basically taking the tmt files from the most relevant state of the dist-git