### PR TITLE
Sync `typing` and `warnings` compat from `tmt`

### DIFF
--- a/fmf/_compat/typing.py
+++ b/fmf/_compat/typing.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 10):
+    from typing import Concatenate, ParamSpec, TypeAlias, TypeGuard
+else:
+    from typing_extensions import Concatenate, ParamSpec, TypeAlias, TypeGuard
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+__all__ = [
+    "Concatenate",
+    "ParamSpec",
+    "Self",
+    "TypeAlias",
+    "TypeGuard",
+    "override",
+    ]

--- a/fmf/_compat/warnings.py
+++ b/fmf/_compat/warnings.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
+
+__all__ = [
+    "deprecated",
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     'ruamel.yaml',
     'filelock',
     'jsonschema',
+    "typing-extensions>=4; python_version < '3.13'",
 ]
 dynamic = ['version']
 


### PR DESCRIPTION
ruff rules are not synced because ruff is not configured here