### PR TITLE
Bump minor versions in hatch version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,10 @@ docs = [
 [project.scripts]
 fmf = 'fmf.cli:cli_entry'
 
-[tool.hatch]
-version.source = 'vcs'
+[tool.hatch.version]
+source = 'vcs'
+raw-options.version_scheme = "release-branch-semver"
+raw-options.git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--abbrev=9", "--match", "*[0-9]*"]
 
 [tool.hatch.envs.default]
 platforms = ["linux"]


### PR DESCRIPTION
Sync with tmt.

This is necessary in order to properly adjust the requirements in tmt on fmf. I.e. we want to use `fmf >= 1.8.0` as that would be the new version, but currently `main` is at `1.7.1.dev3+ga1f9d91b9`