### PR TITLE
Align Context to a read-only dict interface

### DIFF
--- a/fmf/context.py
+++ b/fmf/context.py
@@ -19,7 +19,7 @@ See https://fmf.readthedocs.io/en/latest/modules.html#fmf.Tree.adjust
 import functools
 import re
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import ClassVar, Generic, Optional, TypeVar
 
@@ -524,7 +524,7 @@ class ContextValue:
         return hash(self._to_compare)
 
 
-class Context:
+class Context(Mapping[str, set[ContextValue]]):
     """
     Represents https://fmf.readthedocs.io/en/latest/context.html
     """
@@ -634,6 +634,15 @@ class Context:
             self._dimensions[dimension_name] = set(
                 [self._context_dimensions.create(dimension_name, val) for val in values]
                 )
+
+    def __getitem__(self, key: str) -> set[ContextValue]:
+        return self._dimensions[key]
+
+    def __len__(self):
+        return len(self._dimensions)
+
+    def __iter__(self):
+        yield from self._dimensions
 
     @classmethod
     def parse_rule(cls, rule):

--- a/fmf/context.py
+++ b/fmf/context.py
@@ -21,7 +21,7 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
-from typing import ClassVar, Generic, Optional, TypeVar
+from typing import ClassVar, Generic, Optional, TypeVar, Union
 
 from fmf._compat.typing import TypeAlias
 
@@ -604,7 +604,9 @@ class Context(Mapping[str, set[ContextValue]]):
     # To split by 'or' operator
     re_or_split = re.compile(r'\bor\b')
 
-    def __init__(self, *args, **kwargs):
+    _dimensions: dict[str, set[ContextValue]]
+
+    def __init__(self, **kwargs: Union[str, list[str]]) -> None:
         """
         Context(rule string)
         Context(dimension=ContextValue())
@@ -614,20 +616,6 @@ class Context(Mapping[str, set[ContextValue]]):
         """
         self._dimensions = {}
 
-        # Initialized with rule
-        if args:
-            if len(args) != 1:
-                raise InvalidContext()
-            definition = self.parse_rule(args[0])
-            # No ORs and at least one expression in AND
-            if len(definition) != 1 or not definition[0]:
-                raise InvalidContext()
-            for dim, op, values in definition[0]:
-                if op != "==":
-                    raise InvalidContext()
-                self._dimensions[dim] = set(
-                    [self._context_dimensions.create(dim, val) for val in values])
-        # Initialized with dimension=value(s)
         for dimension_name, values in kwargs.items():
             if not isinstance(values, list):
                 values = [values]

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,7 +1,6 @@
 import pytest
 
-from fmf.context import (CannotDecide, Context, ContextValue, InvalidContext,
-                         InvalidRule)
+from fmf.context import CannotDecide, Context, ContextValue, InvalidRule
 
 
 @pytest.fixture
@@ -246,7 +245,7 @@ class TestExample:
         How you can use context_cls for modules
         """
 
-        perl = context_cls("module = perl:5.28")
+        perl = context_cls(module="perl:5.28")
 
         assert perl.matches("module >= perl:5")
         assert not perl.matches("module > perl:5")
@@ -262,7 +261,7 @@ class TestExample:
         # e.g feature in 5.28+ but dropped in perl6
         assert perl.matches("module ~>= perl:5.28")
         with pytest.raises(CannotDecide):
-            context_cls("module = perl:6.28").matches("module ~>= perl:5.28")
+            context_cls(module="perl:6.28").matches("module ~>= perl:5.28")
 
     def test_comma(self, context_cls: type[Context]):
         """
@@ -621,24 +620,16 @@ class TestParser:
 
 class TestContext:
     def test_creation(self, context_cls: type[Context]):
-        for created in [
-                context_cls(dim_a="value", dim_b=["val"], dim_c=["foo", "bar"]),
-                context_cls("dim_a=value and dim_b=val and dim_c == foo,bar")]:
-            assert created._dimensions["dim_a"] == {
-                context_cls._context_dimensions.create("dim_a", "value")}
-            assert created._dimensions["dim_b"] == {
-                context_cls._context_dimensions.create("dim_b", "val")}
-            assert created._dimensions["dim_c"] == {
-                context_cls._context_dimensions.create(
-                    "dim_c", "foo"), context_cls._context_dimensions.create(
-                    "dim_c", "bar")}
-        # Invalid ways to create context_cls
-        with pytest.raises(InvalidContext):
-            context_cls("a=b", "c=d")  # Just argument
-        with pytest.raises(InvalidContext):
-            context_cls("a=b or c=d")  # Can't use OR
-        with pytest.raises(InvalidContext):
-            context_cls("a < d")  # Operator other than =/==
+        context = context_cls(dim_a="value", dim_b=["val"], dim_c=["foo", "bar"])
+        assert context._dimensions["dim_a"] == {
+            context_cls._context_dimensions.create(
+                "dim_a", "value")}
+        assert context._dimensions["dim_b"] == {
+            context_cls._context_dimensions.create("dim_b", "val")}
+        assert context._dimensions["dim_c"] == {
+            context_cls._context_dimensions.create(
+                "dim_c", "foo"), context_cls._context_dimensions.create(
+                "dim_c", "bar")}
 
     def test_prints(self, context_cls: type[Context]):
         c = context_cls()
@@ -812,18 +803,18 @@ class TestContext:
 
         assert context_cls(distro='fedora-33').matches('distro == fedora')
         with pytest.raises(CannotDecide):
-            context_cls("module = py:5.28").matches("module > perl:5.28")
+            context_cls(module="py:5.28").matches("module > perl:5.28")
         with pytest.raises(CannotDecide):
-            context_cls("module = py:5").matches("module > perl:5.28")
+            context_cls(module="py:5").matches("module > perl:5.28")
         with pytest.raises(CannotDecide):
-            context_cls("module = py:5").matches("module >= perl:5.28")
+            context_cls(module="py:5").matches("module >= perl:5.28")
         with pytest.raises(CannotDecide):
-            context_cls("distro = centos").matches("distro >= fedora")
+            context_cls(distro="centos").matches("distro >= fedora")
 
-        assert context_cls("distro = centos").matches("distro != fedora")
-        assert not context_cls("distro = centos").matches("distro == fedora")
+        assert context_cls(distro="centos").matches("distro != fedora")
+        assert not context_cls(distro="centos").matches("distro == fedora")
 
-        rhel7 = context_cls("distro = rhel-7")
+        rhel7 = context_cls(distro="rhel-7")
         assert rhel7.matches("distro == rhel")
         assert rhel7.matches("distro == rhel-7")
         assert not rhel7.matches("distro == rhel-7.3")


### PR DESCRIPTION
This aligns it with https://github.com/teemtee/tmt/pull/4892 so that they can be later unified and avoid translating between the two after #293