### PR TITLE
Disable testing-farm tag repo

### DIFF
--- a/plans/integration.fmf
+++ b/plans/integration.fmf
@@ -16,6 +16,11 @@ adjust:
     because: >
       We want to test against the tmt main branch
     prepare+:
+      - # TODO: Remove this when multihost pipeline is live
+        summary: Disable testing-farm tag repo
+        how: shell
+        script: |
+          dnf config-manager disable testing-farm-tag-repository || true
       - how: install
         copr: "@teemtee/latest"
     discover+:


### PR DESCRIPTION
This is what causes the intermittent failures in https://github.com/teemtee/fmf/pull/300, e.g. at the moment F45 is in freeze, so the latest version is not updated
```
10:42:00             stdout:  tmt                                  noarch 0:1.77.0-1.fc45      testing-farm-tag-repository   8.1 MiB
10:42:00             stdout:  tmt+provision-container              noarch 0:1.77.0-1.fc45      testing-farm-tag-repository   0.0   B
```
while the version on copr version that it should install is `tmt-1.79.0.dev11+gc0c20b97b-main`